### PR TITLE
Update isort version to 5.12.0 to fix the CI

### DIFF
--- a/{{ cookiecutter.repository_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repository_name }}/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: trailing-whitespace  # trims trailing whitespace.
 
   - repo: https://github.com/PyCQA/isort.git
-    rev: '5.10.1'
+    rev: '5.12.0'
     hooks:
       - id: isort
 


### PR DESCRIPTION
I used your template for my project and the tests of the CI failed. I updated isort and solved the problem.

* lorenzo-delsignore/vision-transformer#2
* [Test before pr](https://github.com/lorenzo-delsignore/vision-transformer/actions/runs/4941518140/jobs/8834190823)
* [Test after pr](https://github.com/lorenzo-delsignore/vision-transformer/actions/runs/4942013306/jobs/8835176029)